### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ArtisanPack UI Livewire Starter Kit
 
+## [1.0.3] - Unreleased
+
+### Added
+- Laravel 13 support: widened `laravel/framework` constraint to `^12.0|^13.0`. Existing Laravel 12 users are unaffected; Laravel 13 is selectable on PHP 8.3+ via L13's own requirements (#9)
+
 ## [1.0.2] - 2026-01-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Laravel and Livewire starter kit featuring ArtisanPack UI components for rapid
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.2 or higher (Laravel 13 requires PHP 8.3+; Composer enforces this automatically)
 - Composer
 - Node.js and NPM
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 A Laravel and Livewire starter kit featuring ArtisanPack UI components for rapidly building modern, responsive web applications.
 
-[![Laravel](https://img.shields.io/badge/Laravel-v12.0-FF2D20?style=flat&logo=laravel&logoColor=white)](https://laravel.com)
+[![Laravel](https://img.shields.io/badge/Laravel-v12_or_v13-FF2D20?style=flat&logo=laravel&logoColor=white)](https://laravel.com)
 [![Livewire](https://img.shields.io/badge/Livewire-v3.6-FB70A9?style=flat&logo=livewire&logoColor=white)](https://livewire.laravel.com)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-v4.1-38B2AC?style=flat&logo=tailwind-css&logoColor=white)](https://tailwindcss.com)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Features
 
-- **Modern Stack**: Built with Laravel 12, Livewire 3, Volt, Flux, and Tailwind CSS 4
+- **Modern Stack**: Built with Laravel 12 or 13, Livewire 3, Volt, Flux, and Tailwind CSS 4
 - **ArtisanPack UI Components**: Pre-built UI components for rapid development
 - **Authentication System**: Complete authentication with login, registration, password reset, and email verification
 - **User Settings**: Profile, password, and appearance management

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "artisanpack-ui/core": "^1.0",
         "artisanpack-ui/livewire-ui-components": "^1.0.0",
         "artisanpack-ui/security": "^1.0",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^12.0|^13.0",
         "laravel/tinker": "^2.10.1",
         "livewire/livewire": "^3.6",
         "livewire/volt": "^1.7"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ This page answers common questions about the Livewire Starter Kit.
 
 The Livewire Starter Kit is a modern Laravel application boilerplate that combines:
 
-- **Laravel 12** - The latest version of the Laravel framework
+- **Laravel 12 or 13** - The Laravel framework (Laravel 13 requires PHP 8.3+)
 - **Livewire 3** - Full-stack framework for Laravel
 - **Volt** - Functional API for Livewire components
 - **ArtisanPack UI** - Modern UI component library
@@ -46,11 +46,11 @@ The starter kit includes:
 
 ### What PHP version is required?
 
-**PHP 8.2 or higher** is required. This ensures compatibility with Laravel 12 and all modern PHP features used in the starter kit.
+**PHP 8.2 or higher** is required for Laravel 12. **Laravel 13 requires PHP 8.3+** (enforced automatically by Composer based on the Laravel version selected).
 
 ### Can I use this with older versions of Laravel?
 
-No, this starter kit is specifically designed for **Laravel 12**. For older Laravel versions, you would need to adapt the code and dependencies accordingly.
+This starter kit supports **Laravel 12 and Laravel 13**. For older Laravel versions, you would need to adapt the code and dependencies accordingly.
 
 ### Does this work with Livewire 2?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ Welcome to the Livewire Starter Kit! This guide will help you understand the key
 
 The starter kit is built with modern technologies:
 
-- **Laravel 12**: The latest version of the Laravel framework
+- **Laravel 12 or 13**: The Laravel framework (Laravel 13 requires PHP 8.3+)
 - **Livewire 3**: Full-stack framework for Laravel
 - **Volt**: Functional API for Livewire
 - **ArtisanPack UI**: Modern UI components

--- a/docs/home.md
+++ b/docs/home.md
@@ -10,7 +10,7 @@ Welcome to the comprehensive documentation for the Livewire Starter Kit - a mode
 
 The Livewire Starter Kit is built with a modern technology stack including:
 
-- **Laravel 12** - The latest version of the Laravel framework
+- **Laravel 12 or 13** - The Laravel framework (Laravel 13 requires PHP 8.3+)
 - **Livewire 3** - Full-stack reactive components
 - **Volt** - A functional API for Livewire
 - **Flux** - Advanced UI components


### PR DESCRIPTION
## Description

Widens `laravel/framework` from `^12.0` to `^12.0|^13.0` so the starter kit can install under Laravel 13 without dropping Laravel 12. Laravel 13 is only selectable on PHP 8.3+ via L13's own `php` constraint — no PHP floor bump is needed for users staying on Laravel 12.

**Closes:** #9

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #9

## Motivation and Context

Laravel 13 was released and requires PHP 8.3+. We need to widen the framework constraint additively so existing Laravel 12 users are unaffected.

## Changes Made

- `composer.json` — widen `laravel/framework` to `^12.0|^13.0`
- `README.md` — Laravel badge updated to `v12_or_v13`; "Modern Stack" feature line now reads "Laravel 12 or 13"
- `CHANGELOG.md` — added `[1.0.3] - Unreleased` entry referencing #9

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 1.0.2 → 1.0.3

**Tests Performed:**
1. `composer install` — clean install against the new constraint
2. `npm install && npm run build` — Vite manifest built
3. `composer test` — full pest suite green (46 tests / 124 assertions)

## Tests Added

No new tests — this is a dependency-constraint change with no behavioral code modifications.

- [x] All tests passing

**Test details:** 46 passed (124 assertions) on PHP 8.4.3 against fresh deps.

## Documentation

- [x] README updated
- [x] CHANGELOG updated

## Follow-ups (out of scope, tracked separately)

- Wire L12/13 into the CI test matrix
- Audit for APIs deprecated/removed in Laravel 13
- Verify all transitive deps (livewire/livewire ^3.6, livewire/volt ^1.7, etc.) cleanly install under L13

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 13 while maintaining Laravel 12 compatibility. Laravel 13 can be selected on systems running PHP 8.3 or higher; Laravel 12 users remain unaffected and the overall minimum PHP requirement stays at 8.2.

* **Documentation**
  * Updated docs and readme to reflect official support for Laravel v12 and v13 and the PHP 8.3+ note for Laravel 13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->